### PR TITLE
make sure filter inserted after restarts on PVs

### DIFF
--- a/src/main/java/org/openshift/jenkins/plugins/openshiftlogin/OpenShiftSetOAuth.java
+++ b/src/main/java/org/openshift/jenkins/plugins/openshiftlogin/OpenShiftSetOAuth.java
@@ -93,6 +93,10 @@ public class OpenShiftSetOAuth {
                         }
                     }
                 }
+            } else {
+                // make sure filter is in place for restart scenarios
+                OpenShiftOAuth2SecurityRealm secRealm = (OpenShiftOAuth2SecurityRealm)priorSecurityRealm;
+                secRealm.createFilter();
             }
         }
         return false;


### PR DESCRIPTION
@openshift/sig-developer-experience @stevekuznetsov fyi / ptal

this fixes @stevekuznetsov 's can't use token without browser login after restarting jenkins in a pod with PVs problem