### PR TITLE
Log token information in debug instead of info

### DIFF
--- a/src/main/java/org/openshift/jenkins/plugins/openshiftlogin/OpenShiftOAuth2SecurityRealm.java
+++ b/src/main/java/org/openshift/jenkins/plugins/openshiftlogin/OpenShiftOAuth2SecurityRealm.java
@@ -423,8 +423,10 @@ public class OpenShiftOAuth2SecurityRealm extends SecurityRealm {
                             this.defaultedServiceAccountDirectory,
                             this.serviceAccountName,
                             this.defaultedServiceAccountName, this.clientId,
-                            this.defaultedClientId, this.clientSecret,
-                            this.defaultedClientSecret, this.redirectURL,
+                            this.defaultedClientId,
+                            Secret.toString(this.clientSecret).substring(0, 5) + ".......",
+                            this.defaultedClientSecret.substring(0, 5) + ".......",
+                            this.redirectURL,
                             this.defaultedRedirectURL, this.serverPrefix,
                             this.defaultedServerPrefix));
 


### PR DESCRIPTION
Too much things is logged there (i.e: token), let's get that in
debug instead.