### PR TITLE
Add user to usersGroup explicitly to avoid edge case

### DIFF
--- a/src/main/java/org/openshift/jenkins/plugins/openshiftlogin/OpenShiftOAuth2SecurityRealm.java
+++ b/src/main/java/org/openshift/jenkins/plugins/openshiftlogin/OpenShiftOAuth2SecurityRealm.java
@@ -784,7 +784,7 @@ public class OpenShiftOAuth2SecurityRealm extends SecurityRealm {
                             .format("OpenShift OAuth: user %s, stored in the matrix as %s, based on OpenShift roles %s already exists in Jenkins",
                                     info.getName(), matrixKey, allowedRoles));
                 } else {
-                    userGroups.add(matrixKey);
+                    usersGroups.add(matrixKey);
                     List<PermissionGroup> permissionGroups = new ArrayList<PermissionGroup>(
                             PermissionGroup.getAll());
                     if (LOGGER.isLoggable(Level.FINE))

--- a/src/main/java/org/openshift/jenkins/plugins/openshiftlogin/OpenShiftOAuth2SecurityRealm.java
+++ b/src/main/java/org/openshift/jenkins/plugins/openshiftlogin/OpenShiftOAuth2SecurityRealm.java
@@ -784,6 +784,7 @@ public class OpenShiftOAuth2SecurityRealm extends SecurityRealm {
                             .format("OpenShift OAuth: user %s, stored in the matrix as %s, based on OpenShift roles %s already exists in Jenkins",
                                     info.getName(), matrixKey, allowedRoles));
                 } else {
+                    userGroups.add(matrixKey)
                     List<PermissionGroup> permissionGroups = new ArrayList<PermissionGroup>(
                             PermissionGroup.getAll());
                     if (LOGGER.isLoggable(Level.FINE))

--- a/src/main/java/org/openshift/jenkins/plugins/openshiftlogin/OpenShiftOAuth2SecurityRealm.java
+++ b/src/main/java/org/openshift/jenkins/plugins/openshiftlogin/OpenShiftOAuth2SecurityRealm.java
@@ -784,7 +784,7 @@ public class OpenShiftOAuth2SecurityRealm extends SecurityRealm {
                             .format("OpenShift OAuth: user %s, stored in the matrix as %s, based on OpenShift roles %s already exists in Jenkins",
                                     info.getName(), matrixKey, allowedRoles));
                 } else {
-                    userGroups.add(matrixKey)
+                    userGroups.add(matrixKey);
                     List<PermissionGroup> permissionGroups = new ArrayList<PermissionGroup>(
                             PermissionGroup.getAll());
                     if (LOGGER.isLoggable(Level.FINE))


### PR DESCRIPTION
When configuring this plugin via a groovy init script running during Jenkins initialization it was discovered that user's roles will not map correctly if there are no existing user groups defined in the authorization strategy, as would be possible via:

~~~ groovy
GlobalMatrixAuthorizationStrategy newAuthMgr = new GlobalMatrixAuthorizationStrategy()
Jenkins.getInstance.setAuthorizationStrategy(newAuthMgr)
~~~

By immediately adding the matrixKey to the usersGroups Set, there will always be at least 1 element for the `for (String userGroup : usersGroups)` loop to iterate over, thus mapping the roles appropriately in this situation. 