### PR TITLE
one more spot of explicit exception logging

### DIFF
--- a/src/main/java/org/openshift/jenkins/plugins/openshiftlogin/OpenShiftSetOAuth.java
+++ b/src/main/java/org/openshift/jenkins/plugins/openshiftlogin/OpenShiftSetOAuth.java
@@ -41,6 +41,7 @@ public class OpenShiftSetOAuth {
             .getName());
     static final String OPENSHIFT_ENABLE_OAUTH = "OPENSHIFT_ENABLE_OAUTH";
     static long lastCheck = 0;
+    static int lastLog = 0;
 
     static boolean setOauth() {
         return setOauth(true);
@@ -77,9 +78,10 @@ public class OpenShiftSetOAuth {
                             try {
                                 inOpenShiftPod = osrealm.populateDefaults();
                             } catch (Throwable t) {
-                                if (LOGGER.isLoggable(Level.FINE))
-                                    LOGGER.log(Level.FINE,
-                                            "OpenShiftItemListener", t);
+                                if ((lastLog % 100) == 0) {
+                                    LOGGER.log(Level.SEVERE, "OpenShiftSetOAuth", t);
+                                }
+                                lastLog++;
                             }
                             LOGGER.info("OpenShift OAuth: running in OpenShift pod with required OAuth features: "
                                     + inOpenShiftPod);
@@ -89,7 +91,20 @@ public class OpenShiftSetOAuth {
                                 return true;
                             }
                         } catch (IOException e1) {
+                            if ((lastLog % 100) == 0) {
+                                LOGGER.log(Level.SEVERE, "OpenShiftSetOAuth", e1);
+                            }
+                            lastLog++;
                         } catch (GeneralSecurityException e1) {
+                            if ((lastLog % 100) == 0) {
+                                LOGGER.log(Level.SEVERE, "OpenShiftSetOAuth", e1);
+                            }
+                            lastLog++;
+                        } catch (Throwable t) {
+                            if ((lastLog % 100) == 0) {
+                                LOGGER.log(Level.SEVERE, "OpenShiftSetOAuth", t);
+                            }
+                            lastLog++;
                         }
                     }
                 }


### PR DESCRIPTION
@openshift/sig-developer-experience fyi

adding this log in a supplied patch assisted in diagnosing a customer issue (where the certs from the master/node were bad) recently discussed on openshift-sme

getting the customer to turn on trace and restart jenkins was problematic ... in theory, the logging will only occur if they are configured to do oauth and want to know what is going on, but added some rudimentary throttling in case somebody has a script with a for loop that is continually hitting the jenkins endpoint ... or our liveness check is tuned super fast, as the filter chain will be executed