### PR TITLE
Add Jenkins' context path (--prefix) to redirectUrl from StaplerRequest

### DIFF
--- a/src/main/java/org/openshift/jenkins/plugins/openshiftlogin/OpenShiftOAuth2SecurityRealm.java
+++ b/src/main/java/org/openshift/jenkins/plugins/openshiftlogin/OpenShiftOAuth2SecurityRealm.java
@@ -61,6 +61,7 @@ import org.kohsuke.stapler.Header;
 import org.kohsuke.stapler.HttpRedirect;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 
 import com.cloudbees.plugins.credentials.CredentialsProvider;
@@ -101,6 +102,7 @@ import hudson.util.FormValidation;
 import hudson.util.HttpResponses;
 import hudson.util.Secret;
 import jenkins.model.Jenkins;
+import jenkins.model.JenkinsLocationConfiguration;
 import jenkins.security.SecurityListener;
 
 /**
@@ -1113,8 +1115,19 @@ public class OpenShiftOAuth2SecurityRealm extends SecurityRealm {
             if (url != null
                     && (url.getProtocol().equalsIgnoreCase("http") || url
                             .getProtocol().equalsIgnoreCase("https"))) {
+                // Get the current request to check if Jenkins was launched with
+                // a prefix set and append it after the URL Host.
+                final String prefix;
+                StaplerRequest req = Stapler.getCurrentRequest();
+
+                if (req != null) {
+                    prefix = req.getContextPath();
+                } else {
+                    prefix = "";
+                }
+
                 return url.getProtocol() + "://" + url.getHost()
-                        + "/securityRealm/finishLogin";
+                        + prefix + "/securityRealm/finishLogin";
             }
         } catch (MalformedURLException e) {
             throw e;

--- a/src/main/java/org/openshift/jenkins/plugins/openshiftlogin/OpenShiftOAuth2SecurityRealm.java
+++ b/src/main/java/org/openshift/jenkins/plugins/openshiftlogin/OpenShiftOAuth2SecurityRealm.java
@@ -102,7 +102,6 @@ import hudson.util.FormValidation;
 import hudson.util.HttpResponses;
 import hudson.util.Secret;
 import jenkins.model.Jenkins;
-import jenkins.model.JenkinsLocationConfiguration;
 import jenkins.security.SecurityListener;
 
 /**


### PR DESCRIPTION
Fixes https://github.com/openshift/jenkins-openshift-login-plugin/issues/69

Summary of Problem:
- If Jenkins is launched using the argument/parameter: `--prefix=`, the generated redirectUrl does not include this specified prefix.

Changes:
- In `OpenShiftOAuth2SecurityRealm::buildOAuthRedirectUrl(...)` call `Stapler.getCurrentRequest()` to get the current `StaplerRequest`.
- If not null, call `.getContextPath()` to get the `--prefix` and add it to the redirectUrl that is built.
- Added a unit test to ensure that when no prefix is specified, the redirectUrl still builds as expected.

Tests:
- `mvn clean package` was run and all tests passed, including the added test.
- Compiled the plugin and uploaded it to a test Jenkins instance.
- Logged out and back in verifying that the redirect_uri generated includes the specified `--prefix` supplied to the Jenkins pod (via `JENKINS_OPTS="--prefix=/jenkins"`)

Notes:
- I attempted to mock `Stapler.getCurrentRequest()` and `StaplerRequest.getContextPath()` for an additional test, however, EasyMock doesn't appear to have a way to mock static methods without using PowerMock - which would be an additional project dependency.
- I used Java reflection to get access to the private `redirectUrl` field in `OAuthSession` for the added unit test, let me know if this is okay.