### PR TITLE
Bug 1752831: Handle HTTP proxy for HTTPS connections

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,17 +43,17 @@
     <dependency>
       <groupId>com.google.oauth-client</groupId>
       <artifactId>google-oauth-client</artifactId>
-      <version>1.20.0</version>
+      <version>1.30.2</version>
     </dependency>
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client-jackson2</artifactId>
-      <version>1.20.0</version>
+      <version>1.30.2</version>
     </dependency>
     <dependency>
       <groupId>com.google.oauth-client</groupId>
       <artifactId>google-oauth-client-java6</artifactId>
-      <version>1.20.0</version>
+      <version>1.30.2</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Starting Java 7/8 , authenticated http and https proxies did not require to set a custom authenticator if the <protocol>.proxy{Host,Port, User, Password} where set.
However, Basic authentication was disabled and needed to be forcibly re-enabled if needed using 
```
-Djdk.http.auth.tunneling.disabledSchemes=""
-Djdk.http.auth.proxying.disabledSchemes=""
```
This works well for http requests, but https request fails with 
```
java.io.IOException: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 407 Proxy Authentication Required"
```
unless a custom authenticator is set.

This PR sets this authenticator if the https.proxyUser or  https.proxyPassword are set.
Note that the update manager of Jenkins seems to be also impacted by this issue.

Updating google-auth-client has been performed in case it was fixing it, but, no changes. However, I made my tests using it, so I didn't want to revert the change.

/assign @gabemontero @adambkaplan 

