### PR TITLE
Bug 1736806: Set fixed locale for role to permission map

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
@@ -17,6 +18,13 @@
     <url>https://github.com/jenkinsci/openshift-login-plugin</url>
     <tag>HEAD</tag>
   </scm>
+
+
+  <properties>
+    <maven.compiler.target>8</maven.compiler.target>
+    <maven.compiler.source>8</maven.compiler.source>
+    <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
+  </properties>
 
   <name>OpenShift Login Plugin</name>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/OpenShift+Login+Plugin</url>
@@ -83,11 +91,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-  		<groupId>org.easymock</groupId>
-  		<artifactId>easymock</artifactId>
-  		<version>3.4</version>
-  		<scope>test</scope>
-	</dependency>
+      <groupId>org.easymock</groupId>
+      <artifactId>easymock</artifactId>
+      <version>3.4</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -119,5 +127,4 @@
       <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
-
 </project>


### PR DESCRIPTION
Edit: Adding description.

This PR fixes bz-1736806 reported by a user using Japanese locale. 
The openshift-login-plugin can use a ConfigMap to describe a matrix based permissions.  The jenkins permissions names are taken from the Jenkins object 'SystemPermission' 

```
systemPermission.group.title.toString().trim();
```

The toString method is "localised" and hence, it uses the user's browser's locale to build the mapping matrix.
This PR forces the SystemPermissiom locale to en_US so this mapping is always performed using the same role names.

