### PR TITLE
Bug 1810429: Hitting the oauth route endpoint instead of the API service

### DIFF
--- a/src/main/java/org/openshift/jenkins/plugins/openshiftlogin/BearerTokenOAuthSession.java
+++ b/src/main/java/org/openshift/jenkins/plugins/openshiftlogin/BearerTokenOAuthSession.java
@@ -31,6 +31,7 @@ import org.kohsuke.stapler.HttpRedirect;
 import org.kohsuke.stapler.HttpResponse;
 
 import com.google.api.client.auth.oauth2.AuthorizationCodeFlow;
+import com.google.api.client.auth.oauth2.AuthorizationCodeTokenRequest;
 import com.google.api.client.auth.oauth2.BearerToken;
 import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.auth.openidconnect.IdTokenResponse;
@@ -58,8 +59,9 @@ public final class BearerTokenOAuthSession extends OAuthSession {
     @Override
     public HttpResponse onSuccess(String authorizationCode) {
         try {
-            IdTokenResponse response = IdTokenResponse
-                    .execute(flow.newTokenRequest(authorizationCode).setRedirectUri(url));
+            LOGGER.info("");
+            AuthorizationCodeTokenRequest tokenRequest = flow.newTokenRequest(authorizationCode).setRedirectUri(url);
+            IdTokenResponse response = IdTokenResponse.execute(tokenRequest);
             final Credential credential = new Credential(BearerToken.authorizationHeaderAccessMethod())
                     .setFromTokenResponse(response);
             this.setCredential(credential);
@@ -68,8 +70,8 @@ public final class BearerTokenOAuthSession extends OAuthSession {
             return new HttpRedirect(redirectOnFinish);
 
         } catch (Throwable e) {
-            if (LOGGER.isLoggable(Level.FINE))
-                LOGGER.log(Level.FINE, "onSuccess", e);
+            if (LOGGER.isLoggable(Level.SEVERE))
+                LOGGER.log(Level.SEVERE, "onSuccess", e);
             return HttpResponses.error(500, e);
         }
     }

--- a/src/main/java/org/openshift/jenkins/plugins/openshiftlogin/OpenShiftVersionInfo.java
+++ b/src/main/java/org/openshift/jenkins/plugins/openshiftlogin/OpenShiftVersionInfo.java
@@ -24,6 +24,8 @@
  */
 package org.openshift.jenkins.plugins.openshiftlogin;
 
+import java.util.logging.Logger;
+
 import com.google.api.client.util.Key;
 
 /**
@@ -32,19 +34,12 @@ import com.google.api.client.util.Key;
  * This is from https://SERVER/version
  */
 /*
- * {
-  "major": "1",
-  "minor": "11+",
-  "gitVersion": "v1.11.0+d4cacc0",
-  "gitCommit": "d4cacc0",
-  "gitTreeState": "clean",
-  "buildDate": "2019-05-02T11:52:09Z",
-  "goVersion": "go1.10.8",
-  "compiler": "gc",
-  "platform": "linux/amd64"
-}
+ * { "major": "1", "minor": "11+", "gitVersion": "v1.11.0+d4cacc0", "gitCommit":
+ * "d4cacc0", "gitTreeState": "clean", "buildDate": "2019-05-02T11:52:09Z",
+ * "goVersion": "go1.10.8", "compiler": "gc", "platform": "linux/amd64" }
  */
 public class OpenShiftVersionInfo {
+    static final Logger LOGGER = Logger.getLogger(OpenShiftVersionInfo.class.getName());
 
     public OpenShiftVersionInfo() {
 
@@ -61,8 +56,40 @@ public class OpenShiftVersionInfo {
 
     @Override
     public String toString() {
-        return "OpenShiftVersionInfo: major: " + major + " minor: "
-                + minor + " gitVersion: " + gitVersion;
+        return "OpenShiftVersionInfo: major: " + major + " minor: " + minor + " gitVersion: " + gitVersion;
+    }
+
+    
+    public boolean isOpenShift3Cluster() {
+        return !isOpenShift4Cluster();
+    }
+    
+    
+    public boolean isOpenShift4Cluster() {
+        if (this.major != null && this.major.equals("1")) {
+            if (this.minor.length() > 1) {
+                String minor = this.minor.substring(0, 2); // per javadoc end index is not inclusive
+                int m = Integer.parseInt(minor);
+                if (m <= 11) {
+                    // 3.x cluster
+                    LOGGER.info("OpenShift OAuth the server is 3.x, specifically " + this.toString());
+                    return false;
+                } else {
+                    // 4.x cluster
+                    LOGGER.info("OpenShift OAuth server is 4.x, specifically " + this.toString());
+                    return true;
+                }
+
+            } else {
+                // 3.x cluster
+                LOGGER.info("OpenShift OAuth the server is 3.x, specifically " + this.toString());
+                return false;
+            }
+        } else {
+            // 3.x cluster
+            LOGGER.info("OpenShift OAuth server is 3.x, specifically " + this.toString());
+            return false;
+        }
     }
 
 }

--- a/src/test/java/org/openshift/jenkins/plugins/openshiftlogin/OpenShiftProviderInfTest.java
+++ b/src/test/java/org/openshift/jenkins/plugins/openshiftlogin/OpenShiftProviderInfTest.java
@@ -1,0 +1,66 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2004-2009, Sun Microsystems, Inc., Kohsuke Kawaguchi
+ * Copyright (c) 2016, Red Hat, Inc., Clayton Coleman
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.openshift.jenkins.plugins.openshiftlogin;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+public class OpenShiftProviderInfTest {
+
+    @Test
+    public void testVersion1dot9() throws Exception {
+        OpenShiftVersionInfo v = new OpenShiftVersionInfo();
+        v.major = "1";
+        v.minor = "9";
+        assertThat(v.isOpenShift4Cluster(), is(false));
+    }
+
+    @Test
+    public void testVersion1dot10() throws Exception {
+        OpenShiftVersionInfo v = new OpenShiftVersionInfo();
+        v.major = "1";
+        v.minor = "10";
+        assertThat(v.isOpenShift4Cluster(), is(false));
+    }
+
+    @Test
+    public void testVersion1dot11() throws Exception {
+        OpenShiftVersionInfo v = new OpenShiftVersionInfo();
+        v.major = "1";
+        v.minor = "11";
+        assertThat(v.isOpenShift4Cluster(), is(false));
+    }
+
+    @Test
+    public void testVersion1dot16() throws Exception {
+        OpenShiftVersionInfo v = new OpenShiftVersionInfo();
+        v.major = "1";
+        v.minor = "16";
+        assertThat(v.isOpenShift4Cluster(), is(true));
+    }
+
+}


### PR DESCRIPTION
- Fix the logic of the method determining which openshift version we are running on
- Fix the token endpoint for 4.x that must be the oauth route not the kubernetes route
- Adding more logs
- Adding a unit test

/assign @waveywaves 