### PR TITLE
map dependency updates of this plugin into jenkins image used for PR testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ target/
 /jpi/
 /Dockerfile-jenkins-ext-oauth
 /sa/
-PR-Testing/
+PR-Testing/jpi/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,15 @@
 # This Dockerfile is intended for use by openshift/ci-operator config files defined
 # in openshift/release for v4.x prow based PR CI jobs
 
-FROM quay.io/openshift/origin-jenkins-agent-maven:v4.0 AS builder
-WORKDIR /java/src/github.com/openshift/jenkins-login-plugin
+FROM quay.io/openshift/origin-jenkins-agent-maven:4.9.0 AS builder
+WORKDIR /java/src/github.com/openshift/jenkins-openshift-login-plugin
 COPY . .
 USER 0
 RUN export PATH=/opt/rh/rh-maven35/root/usr/bin:$PATH && mvn clean package
 
-FROM quay.io/openshift/origin-jenkins:v4.0
+FROM quay.io/openshift/origin-jenkins:4.9.0
 RUN rm /opt/openshift/plugins/openshift-login.jpi
-COPY --from=builder /java/src/github.com/openshift/jenkins-login-plugin/target/openshift-login.hpi /opt/openshift/plugins
+COPY --from=builder /java/src/github.com/openshift/jenkins-openshift-login-plugin/target/openshift-login.hpi /opt/openshift/plugins
 RUN mv /opt/openshift/plugins/openshift-login.hpi /opt/openshift/plugins/openshift-login.jpi
+COPY --from=builder /java/src/github.com/openshift/jenkins-openshift-login-plugin/PR-Testing/download-dependencies.sh /usr/local/bin
+RUN /usr/local/bin/download-dependencies.sh

--- a/PR-Testing/download-dependencies.sh
+++ b/PR-Testing/download-dependencies.sh
@@ -1,0 +1,309 @@
+#! /bin/bash -eu
+#
+# Originally copied from https://github.com/jenkinsci/docker
+# You can set JENKINS_UC to change the default URL to Jenkins update center
+#
+# Usage:
+#
+# FROM openshift/jenkins-2-centos7
+# COPY plugins.txt /plugins.txt
+# RUN /usr/local/bin/install-plugins.sh /plugins.txt
+#
+# The format of 'plugins.txt. is:
+#
+# pluginId:pluginVersion
+
+set -o pipefail
+
+# BEGIN - From https://raw.githubusercontent.com/jenkinsci/docker/master/jenkins-support
+# compare if version1 < version2
+versionLT() {
+    local v1; v1=$(echo "$1" | cut -d '-' -f 1 )
+    local q1; q1=$(echo "$1" | cut -s -d '-' -f 2- )
+    local v2; v2=$(echo "$2" | cut -d '-' -f 1 )
+    local q2; q2=$(echo "$2" | cut -s -d '-' -f 2- )
+    if [ "$v1" = "$v2" ]; then
+        if [ "$q1" = "$q2" ]; then
+            return 1
+        else
+            if [ -z "$q1" ]; then
+                return 1
+            else
+                if [ -z "$q2" ]; then
+                    return 0
+                else
+                    [  "$q1" = "$(echo -e "$q1\n$q2" | sort -V | head -n1)" ]
+                fi
+            fi
+        fi
+    else
+        [  "$v1" = "$(echo -e "$v1\n$v2" | sort -V | head -n1)" ]
+    fi
+}
+
+# returns a plugin version from a plugin archive
+get_plugin_version() {
+    local archive; archive=$1
+    local version; version=$(unzip -p "$archive" META-INF/MANIFEST.MF | grep "^Plugin-Version: " | sed -e 's#^Plugin-Version: ##')
+    version=${version%%[[:space:]]}
+    echo "$version"
+}
+
+# Copy files from /usr/share/jenkins/ref into $JENKINS_HOME
+# So the initial JENKINS-HOME is set with expected content.
+# Don't override, as this is just a reference setup, and use from UI
+# can then change this, upgrade plugins, etc.
+copy_reference_file() {
+    f="${1%/}"
+    b="${f%.override}"
+    rel="${b:23}"
+    version_marker="${rel}.version_from_image"
+    dir=$(dirname "${b}")
+    local action;
+    local reason;
+    local container_version;
+    local image_version;
+    local marker_version;
+    local log; log=false
+    if [[ ${rel} == plugins/*.jpi ]]; then
+        container_version=$(get_plugin_version "$JENKINS_HOME/${rel}")
+        image_version=$(get_plugin_version "${f}")
+        if [[ -e $JENKINS_HOME/${version_marker} ]]; then
+            marker_version=$(cat "$JENKINS_HOME/${version_marker}")
+            if versionLT "$marker_version" "$container_version"; then
+                action="SKIPPED"
+                reason="Installed version ($container_version) has been manually upgraded from initial version ($marker_version)"
+                log=true
+            else
+                if [[ "$image_version" == "$container_version" ]]; then
+                    action="SKIPPED"
+                    reason="Version from image is the same as the installed version $image_version"
+                else
+                    if versionLT "$image_version" "$container_version"; then
+                        action="SKIPPED"
+                        log=true
+                        reason="Image version ($image_version) is older than installed version ($container_version)"
+                    else
+                        action="UPGRADED"
+                        log=true
+                        reason="Image version ($image_version) is newer than installed version ($container_version)"
+                    fi
+                fi
+            fi
+        else
+            if [[ -n "$TRY_UPGRADE_IF_NO_MARKER" ]]; then
+                if [[ "$image_version" == "$container_version" ]]; then
+                    action="SKIPPED"
+                    reason="Version from image is the same as the installed version $image_version (no marker found)"
+                    # Add marker for next time
+                    echo "$image_version" > "$JENKINS_HOME/${version_marker}"
+                else
+                    if versionLT "$image_version" "$container_version"; then
+                        action="SKIPPED"
+                        log=true
+                        reason="Image version ($image_version) is older than installed version ($container_version) (no marker found)"
+                    else
+                        action="UPGRADED"
+                        log=true
+                        reason="Image version ($image_version) is newer than installed version ($container_version) (no marker found)"
+                    fi
+                fi
+            fi
+        fi
+        if [[ ! -e $JENKINS_HOME/${rel} || "$action" == "UPGRADED" || $f = *.override ]]; then
+            action=${action:-"INSTALLED"}
+            log=true
+            mkdir -p "$JENKINS_HOME/${dir:23}"
+            cp -r "${f}" "$JENKINS_HOME/${rel}";
+            # pin plugins on initial copy
+            touch "$JENKINS_HOME/${rel}.pinned"
+            echo "$image_version" > "$JENKINS_HOME/${version_marker}"
+            reason=${reason:-$image_version}
+        else
+            action=${action:-"SKIPPED"}
+        fi
+    else
+        if [[ ! -e $JENKINS_HOME/${rel} || $f = *.override ]]
+        then
+            action="INSTALLED"
+            log=true
+            mkdir -p "$JENKINS_HOME/${dir:23}"
+            cp -r "${f}" "$JENKINS_HOME/${rel}";
+        else
+            action="SKIPPED"
+        fi
+    fi
+    if [[ -n "$VERBOSE" || "$log" == "true" ]]; then
+        if [ -z "$reason" ]; then
+            echo "$action $rel" >> "$COPY_REFERENCE_FILE_LOG"
+        else
+            echo "$action $rel : $reason" >> "$COPY_REFERENCE_FILE_LOG"
+        fi
+    fi
+}
+# END - From https://raw.githubusercontent.com/jenkinsci/docker/master/jenkins-support
+
+REF_DIR=${REF:-/opt/openshift/plugins}
+FAILED="$REF_DIR/failed-plugins.txt"
+
+function getLockFile() {
+    echo -n "$REF_DIR/${1}.lock"
+}
+
+function getArchiveFilename() {
+    echo -n "$REF_DIR/${1}.jpi"
+}
+
+function download() {
+    local plugin originalPlugin version lock ignoreLockFile
+    plugin="$1"
+    version="${2:-latest}"
+    ignoreLockFile="${3:-}"
+    lock="$(getLockFile "$plugin")"
+
+    if [[ $ignoreLockFile ]] || mkdir "$lock" &>/dev/null; then
+        if ! doDownload "$plugin" "$version"; then
+            # some plugin don't follow the rules about artifact ID
+            # typically: docker-plugin
+            originalPlugin="$plugin"
+            plugin="${plugin}-plugin"
+            if ! doDownload "$plugin" "$version"; then
+                echo "Failed to download plugin: $originalPlugin or $plugin" >&2
+                echo "Not downloaded: ${originalPlugin}" >> "$FAILED"
+                return 1
+            fi
+        fi
+
+        if ! checkIntegrity "$plugin"; then
+            echo "Downloaded file is not a valid ZIP: $(getArchiveFilename "$plugin")" >&2
+            echo "Download integrity: ${plugin}" >> "$FAILED"
+            return 1
+        fi
+
+        resolveDependencies "$plugin"
+    fi
+}
+
+function doDownload() {
+    local plugin version url jpi
+    plugin="$1"
+    version="$2"
+    jpi="$(getArchiveFilename "$plugin")"
+
+    # If plugin already exists and is the same version do not download
+    if test -f "$jpi" && unzip -p "$jpi" META-INF/MANIFEST.MF | tr -d '\r' | grep "^Plugin-Version: ${version}$" > /dev/null; then
+        echo "Using provided plugin: $plugin"
+        return 0
+    fi
+
+    JENKINS_UC_DOWNLOAD=${JENKINS_UC_DOWNLOAD:-"$JENKINS_UC/download"}
+
+    url="$JENKINS_UC_DOWNLOAD/plugins/$plugin/$version/${plugin}.hpi"
+
+    echo "Downloading plugin: $plugin from $url"
+    curl --connect-timeout 5 --retry 5 --retry-delay 0 --retry-max-time 60 -s -f -L "$url" -o "$jpi"
+    return $?
+}
+
+function checkIntegrity() {
+    local plugin jpi
+    plugin="$1"
+    jpi="$(getArchiveFilename "$plugin")"
+
+    zip -T "$jpi" >/dev/null
+    return $?
+}
+
+function resolveDependencies() {
+    local plugin jpi dependencies
+    plugin="$1"
+    jpi="$(getArchiveFilename "$plugin")"
+
+    set +o pipefail
+    dependencies="$(unzip -p "$jpi" META-INF/MANIFEST.MF | tr -d '\r' | tr '\n' '|' | sed -e 's#| ##g' | tr '|' '\n' | grep "^Plugin-Dependencies: " | sed -e 's#^Plugin-Dependencies: ##')"
+    set -o pipefail
+
+    if [[ ! $dependencies ]]; then
+        echo " > $plugin has no dependencies"
+        return
+    fi
+
+    echo " > $plugin depends on $dependencies"
+
+    IFS=',' read -a array <<< "$dependencies"
+
+    for d in "${array[@]}"
+    do
+        plugin="$(cut -d':' -f1 - <<< "$d")"
+        #
+        # Note, matrix-auth plugin notes cloudbees-folder as optional in the archive, but then failed to
+        # load, citing a dependency that is too old, during testing ... so we will download optional dependencies
+        #
+        local versionFromPluginParam
+        if [[ $d == *"resolution:=optional"* ]]; then
+            echo "Examining optional dependency $plugin"
+	    optional_jpi="$(getArchiveFilename "$plugin")"
+	    if [ ! -f "${optional_jpi}" ]; then
+		echo "Optional dependency $plugin not installed already, skipping"
+		continue
+	    fi
+	    echo "Optional dependency $plugin already installed, need to determine if it is at a sufficient version"
+            versionFromPluginParam="$(cut -d';' -f1 - <<< "$d")"
+	else
+            versionFromPluginParam=$d
+        fi
+        local pluginInstalled
+        local minVersion; minVersion=$(versionFromPlugin "${versionFromPluginParam}")
+
+	set +o pipefail
+	local filename; filename=$(getArchiveFilename "$plugin")
+	local previouslyDownloadedVersion; previouslyDownloadedVersion=$(get_plugin_version $filename)
+	set -o pipefail
+	
+        # if the dependency plugin has yet to be downloaded (hence the var is not set) download
+        if [[ -z "${previouslyDownloadedVersion:-}" ]]; then
+            echo "Downloading dependency plugin $plugin version $minVersion that has yet to be installed"
+            download "$plugin" "$minVersion"
+        else
+            # get the version of the dependency plugin already downloaded; if not recent enough, download
+            # the minimum version required; the "true" parameter is need for "download" to overwrite the existing
+            # version of the plugin
+            if versionLT "${previouslyDownloadedVersion}" "${minVersion}"; then
+                echo "Upgrading previously downloaded plugin $plugin at $previouslyDownloadedVersion to $minVersion"
+                download "$plugin" "$minVersion" "true"
+            fi
+        fi
+    done
+    wait
+}
+
+function versionFromPlugin() {
+    local plugin=$1
+    if [[ $plugin =~ .*:.* ]]; then
+        echo "${plugin##*:}"
+    else
+        echo "latest"
+    fi
+
+}
+
+function installedPlugins() {
+    for f in "$REF_DIR"/*.jpi; do
+        echo "$(basename "$f" | sed -e 's/\.jpi//'):$(get_plugin_version "$f")"
+    done
+}
+
+main() {
+    local plugin version
+
+    mkdir -p "$REF_DIR" || exit 1
+
+    resolveDependencies "openshift-sync"
+    
+    echo
+    echo "Installed plugins:"
+    installedPlugins
+
+}
+
+main "$@"


### PR DESCRIPTION
@openshift/team-devtools-jenkins @openshift/openshift-team-build-api FYI

the recent efforts to cut v1.0.48 of the sync plugin revealed the need to update our in-repo e2e to make plugin dependency updates into the image CI builds for the test run

See https://github.com/openshift/jenkins-sync-plugin/commit/9fa9d404711a328ba71cc8b7bc0012cf53dba7d1 for reference

/assign @akram
/assign @waveywaves
/assign @jkhelil 

Which ever of you three ^^ can review this first, and tag if it is OK, please do so.

Any obvious typos where the image build is bad should be caught by the e2e