### PR TITLE
Support permissions with space like 'Lockable Resources'

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ Finally, permissions for users in Jenkins, and OpenShift to Jenkins permission m
 Jenkins for each Jenkins user with the permissions retrieved from OpenShift.  Technically speaking, you can change the permissions for a Jenkins user from the Jenkins UI as well, but those changes will be overwritten the next
 time the poll occurs.
 
+Some permission like `Lockable Resources` contains spaces. In order to configure them using config map, the space must be replaced by an '_'.
+
+For example `Lockable_Resources-Unlock: 'view,edit'`
+
 You can control how often the polling occurs with the `OPENSHIFT_PERMISSIONS_POLL_INTERVAL` environment variable.  The default polling interval when no environment variable is set is 5 minutes.
 
 #### Using custom Roles

--- a/src/main/java/org/openshift/jenkins/plugins/openshiftlogin/OpenShiftOAuth2SecurityRealm.java
+++ b/src/main/java/org/openshift/jenkins/plugins/openshiftlogin/OpenShiftOAuth2SecurityRealm.java
@@ -752,7 +752,7 @@ public class OpenShiftOAuth2SecurityRealm extends SecurityRealm implements Seria
         for (Entry<String, String> entry : response.data.entrySet()) {
             String permissionAsString = entry.getKey();
 
-            String[] parsedPermission = permissionAsString.trim().split("-");
+            String[] parsedPermission = permissionAsString.replace("_", " ").trim().split("-");
             if (parsedPermission == null || parsedPermission.length != 2) {
                 LOGGER.info(prefix + " ignore permission string " + permissionAsString
                         + " since if is not of the form <permGroupId>-<permId>");


### PR DESCRIPTION
Hi,

This PR fix https://github.com/openshift/jenkins-openshift-login-plugin/issues/123

Config map key doesn't support space. It prevent to configure some permission like 'Lockable Resources'.

Tested and working

```
kind: ConfigMap
apiVersion: v1
metadata:
  name: openshift-jenkins-login-plugin-config
data:
 ....
  Lockable_Resources-Unlock: 'view,edit'
  Lockable_Resources-View: 'view,edit'
  Lockable_Resources-Reserve: 'view,edit'
  .....
```

![lockage_resource](https://user-images.githubusercontent.com/825750/155496911-0192b712-e8a9-4183-b8e3-09aeb9c86169.png)

Regards,