### PR TITLE
update matrix-auth plugin and use spring boot classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>matrix-auth</artifactId>
-      <version>1.1</version>
+      <version>3.1.2</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/org/openshift/jenkins/plugins/openshiftlogin/OpenShiftPermissionFilter.java
+++ b/src/main/java/org/openshift/jenkins/plugins/openshiftlogin/OpenShiftPermissionFilter.java
@@ -28,6 +28,7 @@ import static java.util.logging.Level.SEVERE;
 import static org.openshift.jenkins.plugins.openshiftlogin.OAuthSession.SESSION_NAME;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map.Entry;
 import java.util.logging.Level;
@@ -42,9 +43,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
-import org.acegisecurity.GrantedAuthority;
-import org.acegisecurity.context.SecurityContextHolder;
-import org.acegisecurity.providers.UsernamePasswordAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import com.google.api.client.auth.oauth2.BearerToken;
 import com.google.api.client.auth.oauth2.Credential;
@@ -181,7 +181,7 @@ public class OpenShiftPermissionFilter implements Filter {
                                     entry.lastCheck = 0;
                                     // we check for first time in case system time is say reset to 1970
                                     // (perhaps we are in a VM that just spun up and the time has not been set)
-                                    // we are not going to bother finding a negative number big enough to ensure 
+                                    // we are not going to bother finding a negative number big enough to ensure
                                     // we are greater than interval * 100 in this case
                                     firstTime = true;
                                 }
@@ -211,7 +211,7 @@ public class OpenShiftPermissionFilter implements Filter {
                                 } else if (entry.token != null) {
                                     SecurityContextHolder.getContext()
                                             .setAuthentication(entry.token);
-                                    SecurityListener.fireAuthenticated(new OpenShiftUserDetails(entry.token.getName(), new GrantedAuthority[] { SecurityRealm.AUTHENTICATED_AUTHORITY }));
+                                    SecurityListener.fireAuthenticated2(new OpenShiftUserDetails(entry.token.getName(), Collections.singletonList(SecurityRealm.AUTHENTICATED_AUTHORITY2)));
                                 } else {
                                     HttpServletResponse httpResponse = (HttpServletResponse) response;
                                     httpResponse.sendError(401, NEED_TO_AUTH);

--- a/src/main/java/org/openshift/jenkins/plugins/openshiftlogin/OpenShiftUserDetails.java
+++ b/src/main/java/org/openshift/jenkins/plugins/openshiftlogin/OpenShiftUserDetails.java
@@ -24,25 +24,27 @@
  */
 package org.openshift.jenkins.plugins.openshiftlogin;
 
-import org.acegisecurity.GrantedAuthority;
-import org.acegisecurity.userdetails.UserDetails;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
 
 @SuppressWarnings("serial")
 @SuppressFBWarnings
 public class OpenShiftUserDetails implements UserDetails {
-    
-    private String name;
-    private GrantedAuthority[] authorities;
 
-    public OpenShiftUserDetails(String name, GrantedAuthority[] auths) {
+    private String name;
+    private Collection<? extends GrantedAuthority> authorities;
+
+    public OpenShiftUserDetails(String name, Collection<? extends GrantedAuthority> auths) {
         this.name = name;
         this.authorities = auths;
     }
-    
+
     @Override
-    public GrantedAuthority[] getAuthorities() {
+    public Collection<? extends GrantedAuthority> getAuthorities() {
         return this.authorities;
     }
 


### PR DESCRIPTION
Newer versions of matrix-auth plugin needs to differentiate between user and groups.
The current version is still working, but deprecated and shows warnings in the jenkins UI.

This PR updates the matrix-auth plugin and corresponding spring boot classes to create proper permissions.