### PR TITLE
Ability to map permissions to Jenkins groups

### DIFF
--- a/src/main/java/org/openshift/jenkins/plugins/openshiftlogin/OpenShiftOAuth2SecurityRealm.java
+++ b/src/main/java/org/openshift/jenkins/plugins/openshiftlogin/OpenShiftOAuth2SecurityRealm.java
@@ -962,7 +962,9 @@ public class OpenShiftOAuth2SecurityRealm extends SecurityRealm implements Seria
             // browser window;
             // we'll display the "core" user name without the admin/edit/view
             // suffix
-            u.setFullName(info.getName());
+            if( ! this.mapRolesToGroups ) {
+                u.setFullName(info.getName());
+            }
             u.save();
             SecurityListener.fireAuthenticated(new OpenShiftUserDetails(token.getName(), authorities));
 

--- a/src/main/java/org/openshift/jenkins/plugins/openshiftlogin/OpenShiftSetOAuth.java
+++ b/src/main/java/org/openshift/jenkins/plugins/openshiftlogin/OpenShiftSetOAuth.java
@@ -73,7 +73,7 @@ public class OpenShiftSetOAuth {
                         lastCheck = System.currentTimeMillis();
                         try {
                             final OpenShiftOAuth2SecurityRealm osrealm = new OpenShiftOAuth2SecurityRealm(
-                                    null, null, null, null, null, null);
+                                    null, null, null, null, null, null, false);
                             boolean inOpenShiftPod = false;
                             try {
                                 inOpenShiftPod = osrealm.populateDefaults();

--- a/src/main/java/org/openshift/jenkins/plugins/openshiftlogin/OpenShiftUserInfo.java
+++ b/src/main/java/org/openshift/jenkins/plugins/openshiftlogin/OpenShiftUserInfo.java
@@ -56,6 +56,9 @@ public class OpenShiftUserInfo extends UserProperty {
     @Key
     public String email;
 
+    @Key
+    public String fullName;
+
     public String getEmail() {
         return email;
     }
@@ -75,8 +78,13 @@ public class OpenShiftUserInfo extends UserProperty {
         if (email != null)
             u.addProperty(new Mailer.UserProperty(email));
 
-        if (getName() != null)
-            u.setFullName(getName());
+        if (fullName != null) {
+            u.setFullName(fullName);
+        } else {
+            if (getName() != null) {
+                u.setFullName(getName());
+            }
+        }
 
         u.addProperty(this);
     }

--- a/src/main/resources/org/openshift/jenkins/plugins/openshiftlogin/OpenShiftOAuth2SecurityRealm/config.jelly
+++ b/src/main/resources/org/openshift/jenkins/plugins/openshiftlogin/OpenShiftOAuth2SecurityRealm/config.jelly
@@ -18,4 +18,7 @@
   <f:entry title="${%Client Secret}" field="clientSecret">
     <f:password/>
   </f:entry>
+  <f:entry title="${%Assign permissions to Jenkins groups instead of users}" field="mapRolesToGroups">
+    <f:checkbox/>
+  </f:entry>
 </j:jelly>

--- a/src/test/java/org/openshift/jenkins/plugins/openshiftlogin/OpenShiftOAuth2SecurityRealmTest.java
+++ b/src/test/java/org/openshift/jenkins/plugins/openshiftlogin/OpenShiftOAuth2SecurityRealmTest.java
@@ -118,7 +118,7 @@ public class OpenShiftOAuth2SecurityRealmTest {
         String port = ":1234";
         String context = "/my-context";
         String redir = origin + port + context;
-        OpenShiftOAuth2SecurityRealm realm = new OpenShiftOAuth2SecurityRealm(null, null, server, id, secret, redir);
+        OpenShiftOAuth2SecurityRealm realm = new OpenShiftOAuth2SecurityRealm(null, null, server, id, secret, redir, false);
         String url = realm.buildOAuthRedirectUrl(redir);
         assertThat(url, is(origin + port + SECURITY_REALM_FINISH_LOGIN));
     }
@@ -129,7 +129,7 @@ public class OpenShiftOAuth2SecurityRealmTest {
         String port = ":443";
         String context = "/my-context";
         String redir = origin + port + context;
-        OpenShiftOAuth2SecurityRealm realm = new OpenShiftOAuth2SecurityRealm(null, null, server, id, secret, redir);
+        OpenShiftOAuth2SecurityRealm realm = new OpenShiftOAuth2SecurityRealm(null, null, server, id, secret, redir, false);
         String url = realm.buildOAuthRedirectUrl(redir);
         assertThat(url, is(origin + SECURITY_REALM_FINISH_LOGIN));
     }
@@ -140,7 +140,7 @@ public class OpenShiftOAuth2SecurityRealmTest {
         String port = ":12345";
         String context = "/my-context";
         String redir = origin + port + context;
-        OpenShiftOAuth2SecurityRealm realm = new OpenShiftOAuth2SecurityRealm(null, null, server, id, secret, redir);
+        OpenShiftOAuth2SecurityRealm realm = new OpenShiftOAuth2SecurityRealm(null, null, server, id, secret, redir, false);
         String url = realm.buildOAuthRedirectUrl(redir);
         assertThat(url, is(origin + port + SECURITY_REALM_FINISH_LOGIN));
     }
@@ -151,14 +151,14 @@ public class OpenShiftOAuth2SecurityRealmTest {
         String port = ":80";
         String context = "/my-context";
         String redir = origin + port + context;
-        OpenShiftOAuth2SecurityRealm realm = new OpenShiftOAuth2SecurityRealm(null, null, server, id, secret, redir);
+        OpenShiftOAuth2SecurityRealm realm = new OpenShiftOAuth2SecurityRealm(null, null, server, id, secret, redir, false);
         String url = realm.buildOAuthRedirectUrl(redir);
         assertThat(url, is(origin + SECURITY_REALM_FINISH_LOGIN));
     }
 
     @Test
     public void testLoginUrl() throws Exception {
-        OpenShiftOAuth2SecurityRealm realm = new OpenShiftOAuth2SecurityRealm(null, null, server, id, secret, server);
+        OpenShiftOAuth2SecurityRealm realm = new OpenShiftOAuth2SecurityRealm(null, null, server, id, secret, server, false);
         assertThat(realm.getLoginUrl(), is("securityRealm/commenceLogin"));
     }
 
@@ -166,7 +166,7 @@ public class OpenShiftOAuth2SecurityRealmTest {
     public void testAuthorizeRedirect() throws Exception {
         OpenShiftOAuth2SecurityRealm.testTransport = new NetHttpTransport.Builder().doNotValidateCertificate().build();
         final OpenShiftOAuth2SecurityRealm realm = new OpenShiftOAuth2SecurityRealm(null, null, server, id, secret,
-                server);
+                server, false);
         realm.redirectUrl = "http://localhost:19191/jenkins" + SECURITY_REALM_FINISH_LOGIN;
 
         OAuthSession s = realm.newOAuthSession("http://localhost/start", "http://localhost/done");
@@ -236,7 +236,7 @@ public class OpenShiftOAuth2SecurityRealmTest {
     @Test
     public void testPodDefaults() throws Exception {
         final OpenShiftOAuth2SecurityRealm realm = new OpenShiftOAuth2SecurityRealm(null, null, server, id, secret,
-                server);
+                server, false);
         assertThat(realm.populateDefaults(), is(false));
         assertThat(realm.getDefaultedServerPrefix(), is(OpenShiftOAuth2SecurityRealm.DEFAULT_SVR_PREFIX));
         assertThat(realm.getDefaultedServiceAccountDirectory(), is(OpenShiftOAuth2SecurityRealm.DEFAULT_SVC_ACCT_DIR));
@@ -245,7 +245,7 @@ public class OpenShiftOAuth2SecurityRealmTest {
     @Test
     public void testBuildOAuthRedirectUrlWithoutPrefix() throws Exception {
         final OpenShiftOAuth2SecurityRealm realm = new OpenShiftOAuth2SecurityRealm(null, null, server, id, secret,
-                server);
+                server, false);
         // Create a new OAuthSession with a redirectUrl with a long path
         OAuthSession session = realm.newOAuthSession("from", "https://example.com/jenkins/extra/path");
 
@@ -265,7 +265,7 @@ public class OpenShiftOAuth2SecurityRealmTest {
     @Test
     public void testBuildOAuthRedirectUrlWithPrefixWithPort() throws Exception {
         final OpenShiftOAuth2SecurityRealm realm = new OpenShiftOAuth2SecurityRealm(null, null, server, id, secret,
-                server);
+                server, false);
         // Create a new OAuthSession with a redirectUrl with a long path
         OAuthSession session = realm.newOAuthSession("from", "https://example.com:1234/jenkins/extra/path");
         // Find private 'redirectUrl' field using Java Reflection and assert it doesn't


### PR DESCRIPTION
I added the ability to map OpenShift roles to Jenkins groups.

This solves an issue: https://github.com/openshift/jenkins-openshift-login-plugin/issues/131

The problem is, when you enable Project-based matrix security model in Jenkins, and have many users, you must manually add permissions for every user in every project. And, if user's permissions are changed in openshift, do that again.

Alternative is to use Jenkins groups. With them, you're able to map project's permissions to groups only once, and manage mapping of users to groups with OpenShift ConfigMap.

This feature is enabled through configuration checkbox in Jenkins UI. If checkbox is not set, old behaviour is in place.

P.S. Really I am not the developer, I am system admin, so may be the code is not good enough and not covered by tests (really, I don't know how to do them yet ;), but I tested and using it on my environment. May be someone will help me to get this PR merged.

<!--
Put an `x` into the [x] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md
You can override it by creating .github/pull_request_template.md  in your own repository
-->
