### PR TITLE
OCPBUGS-903: Bump google-oauth-client dependency to 1.34.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>com.google.oauth-client</groupId>
       <artifactId>google-oauth-client</artifactId>
-      <version>1.30.2</version>
+      <version>1.34.1</version>
     </dependency>
     <dependency>
       <groupId>com.google.http-client</groupId>


### PR DESCRIPTION
`google-oauth-client` `1.30.2` version was vulnerable. Therefore bumping that to `1.34.1`

Signed-off-by: divyansh42 <diagrawa@redhat.com>