### PR TITLE
JKNS-571: Bump jenkins from 2.426.2 to 2.440.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <properties>
     <revision>1.1.0</revision>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.version>2.426.2</jenkins.version>
+    <jenkins.version>2.440.3</jenkins.version>
     <log.level>INFO</log.level>
   </properties>
 
@@ -93,8 +93,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.426.x</artifactId>
-        <version>2705.vf5c48c31285b_</version>
+        <artifactId>bom-2.440.x</artifactId>
+        <version>3413.v0d896b_76a_30d</version>
         <scope>import</scope>
         <type>pom</type>
     </dependency>
@@ -109,25 +109,16 @@
       <version>1.35.0</version>
     </dependency>
     <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>mailer</artifactId>
-      <version>463.vedf8358e006b_</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>matrix-auth</artifactId>
-      <version>3.2.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>credentials</artifactId>
-      <version>1311.vcf0a_900b_37c2</version>
-    </dependency>
-    <dependency>
       <groupId>org.easymock</groupId>
       <artifactId>easymock</artifactId>
       <version>5.1.0</version>
       <scope>test</scope>
+    </dependency>
+    <!-- Pin com.google.errorprone:error_prone_annotations version for com.google.http-client:google-http-client:1.43.3 and com.google.guava:guava:33.0.0-jre -->
+    <dependency>
+      <groupId>com.google.errorprone</groupId>
+      <artifactId>error_prone_annotations</artifactId>
+      <version>2.23.0</version>
     </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
- Bump `jenkins` from `2.426.2` to `2.440.3`
- Bump `jenkins` `bom` from `2705.vf5c48c31285b_` to `3413.v0d896b_76a_30d`
- Add transitive dependency `com.google.errorprone:error_prone_annotations:2.23.0`
- Remove transitive dependencies \
  `org.jenkins-ci.plugins:mailer:463.vedf8358e006b_` \
  `org.jenkins-ci.plugins:matrix-auth:3.2.1` \
  `org.jenkins-ci.plugins:credentials:1311.vcf0a_900b_37c2`