### PR TITLE
JKNS-456: update builder image to use JDK21 based image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,14 @@
 # This Dockerfile is intended for use by openshift/ci-operator config files defined
 # in openshift/release for v4.x prow based PR CI jobs
 
-FROM quay.io/openshift/origin-jenkins-agent-maven:4.11.0 AS builder
+FROM registry.access.redhat.com/ubi9/openjdk-21:1.20 AS builder
 WORKDIR /java/src/github.com/openshift/jenkins-openshift-login-plugin
 COPY . .
 USER 0
-# We need a newer maven version as the RHEL package is still on 3.6.2
-RUN curl -L -o maven.tar.gz https://dlcdn.apache.org/maven/maven-3/3.8.8/binaries/apache-maven-3.8.8-bin.tar.gz && \
-	mkdir maven && \
-	tar -xvzf maven.tar.gz -C maven --strip-component 1
+
 # Use the downloaded version of maven to build the package
-RUN ./maven/bin/mvn --version && \
-	./maven/bin/mvn clean package
+RUN mvn --version
+RUN mvn clean package
 
 FROM registry.redhat.io/ocp-tools-4/jenkins-rhel8:v4.14.0
 RUN rm /opt/openshift/plugins/openshift-login.jpi


### PR DESCRIPTION
- Update builder image to use JDK21 based image

/cherry-pick release-4.18 release-4.17 release-4.16 release-4.15 release-4.14 release-4.13 release-4.12

