### PR TITLE
JKNS-571: Update jenkins baseline version from 2.426.2 to 2.504.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,16 @@ FROM registry.access.redhat.com/ubi9/openjdk-21:1.20 AS builder
 WORKDIR /java/src/github.com/openshift/jenkins-openshift-login-plugin
 COPY . .
 USER 0
+# We need a newer maven version as the RHEL package is still on 3.8.5
+RUN microdnf -y install gzip && \
+	curl -L -o maven.tar.gz https://archive.apache.org/dist/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz && \
+	mkdir maven && \
+	tar -xvzf maven.tar.gz -C maven --strip-component 1 && \
+	# Use the downloaded version of maven to build the package
+	./maven/bin/mvn --version && \
+	./maven/bin/mvn clean package
 
-# Use the downloaded version of maven to build the package
-RUN mvn --version
-RUN mvn clean package
-
-FROM registry.redhat.io/ocp-tools-4/jenkins-rhel8:v4.14.0
+FROM registry.redhat.io/ocp-tools-4/jenkins-rhel9:v4.17.0
 RUN rm /opt/openshift/plugins/openshift-login.jpi
 COPY --from=builder /java/src/github.com/openshift/jenkins-openshift-login-plugin/target/openshift-login.hpi /opt/openshift/plugins
 RUN mv /opt/openshift/plugins/openshift-login.hpi /opt/openshift/plugins/openshift-login.jpi

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.77</version>
+    <version>5.18</version>
     <relativePath />
   </parent>
   <groupId>org.openshift.jenkins</groupId>
@@ -14,7 +14,7 @@
   <properties>
     <revision>1.1.0</revision>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.version>2.426.2</jenkins.version>
+    <jenkins.version>2.504.2</jenkins.version>
     <log.level>INFO</log.level>
   </properties>
 
@@ -93,40 +93,30 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.426.x</artifactId>
-        <version>2705.vf5c48c31285b_</version>
+        <artifactId>bom-2.504.x</artifactId>
+        <version>4969.v6ffa_18d90c9f</version>
         <scope>import</scope>
         <type>pom</type>
     </dependency>
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client-jackson2</artifactId>
-      <version>1.43.3</version>
+      <version>1.47.1</version>
     </dependency>
     <dependency>
       <groupId>com.google.oauth-client</groupId>
       <artifactId>google-oauth-client-java6</artifactId>
-      <version>1.35.0</version>
+      <version>1.39.0</version>
     </dependency>
     <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>mailer</artifactId>
-      <version>463.vedf8358e006b_</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>matrix-auth</artifactId>
-      <version>3.2.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>credentials</artifactId>
-      <version>1311.vcf0a_900b_37c2</version>
+      <groupId>com.google.errorprone</groupId>
+      <artifactId>error_prone_annotations</artifactId>
+      <version>2.36.0</version>
     </dependency>
     <dependency>
       <groupId>org.easymock</groupId>
       <artifactId>easymock</artifactId>
-      <version>5.1.0</version>
+      <version>5.6.0</version>
       <scope>test</scope>
     </dependency>
     </dependencies>
@@ -137,7 +127,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>versions-maven-plugin</artifactId>
-        <version>2.16.0</version>
+        <version>2.18.0</version>
         <configuration>
           <excludes>
             <exclude>org.apache.commons:commons-collections4</exclude>
@@ -147,7 +137,7 @@
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
-        <version>4.8.2.0</version>
+        <version>4.9.3.1</version>
         <configuration>
             <failOnError>false</failOnError>
         </configuration>
@@ -156,14 +146,14 @@
             <dependency>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs</artifactId>
-                <version>4.8.3</version>
+                <version>4.9.3</version>
             </dependency>
         </dependencies>
     </plugin>
       <plugin>
         <groupId>org.jenkins-ci.tools</groupId>
         <artifactId>maven-hpi-plugin</artifactId>
-        <version>3.47</version>
+        <version>3.65</version>
         <configuration>
           <pluginFirstClassLoader>true</pluginFirstClassLoader>
           <loggers>
@@ -195,7 +185,7 @@
       <plugin>
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>
-        <version>4.2</version>
+        <version>5.0.0</version>
         <configuration>
           <aggregate>true</aggregate>
           <header>header.txt</header>
@@ -227,7 +217,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.1.0</version>
+            <version>3.2.7</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -241,7 +231,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-enforcer-plugin</artifactId>
-            <version>3.3.0</version>
+            <version>3.5.0</version>
             <executions>
               <execution>
                 <id>enforce-no-snapshots</id>
@@ -263,7 +253,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.5.0</version>
+            <version>3.11.2</version>
             <executions>
               <execution>
                 <id>attach-javadocs</id>
@@ -276,7 +266,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
-            <version>3.3.0</version>
+            <version>3.3.1</version>
             <executions>
               <execution>
                 <id>attach-sources</id>


### PR DESCRIPTION
- Bump jenkins from `2.426.2` to `2.504.2`
- Bump jenkins bom from `2705.vf5c48c31285b_` to `4969.v6ffa_18d90c9f`
- Add transitive dependency `com.google.errorprone:error_prone_annotations:2.36.0`
- Remove transitive dependencies 
   `org.jenkins-ci.plugins:mailer:463.vedf8358e006b_ `
   `org.jenkins-ci.plugins:matrix-auth:3.2.1`  
   `org.jenkins-ci.plugins:credentials:1311.vcf0a_900b_37c2`